### PR TITLE
ConnectionClose error

### DIFF
--- a/System.Net.Http/System.Net.Http/HttpClientHandler.cs
+++ b/System.Net.Http/System.Net.Http/HttpClientHandler.cs
@@ -369,7 +369,8 @@ namespace System.Net.Http
 					break;
 
 				case "connection":
-					request.Connection = headers.Connection.ToString ();
+                    // HttpWebRequest throws an exception if setting the Connection property.
+                    // Use the KeepAlive property instead of this
 					break;
 
 				case "date":


### PR DESCRIPTION
HttpClient throws an ArgumentException when setting the DefaultRequestHeaders.ConnectionClose property.
I removed the process of setting the HttpWebRequest.Connection property for the error (see also: https://msdn.microsoft.com/en-us/library/system.net.httpwebrequest.connection.aspx ).
